### PR TITLE
Add compositional extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A simple, fast, and un-opinionated table component for React.
 
-It is small (900 bytes after gzip) and has no dependencies.
+It is small (900 bytes after gzip), has no dependencies, and is [easy to extend via composition](#composition).
 
 ## Installation
 
@@ -97,13 +97,44 @@ const data = [
 
 `cellKey` does not currently support nested properties (eg. `obj.a.b.c`). If you need to access nested properties, we recommend you use `cell` instead.
 
+## Composition
+
+Part of the beauty of React is being able to compose small pieces of functionality into complex UIs. By leveraging [higher-order components](https://facebook.github.io/react/docs/higher-order-components.html), we can extend Knoll with features we need in an organized and reusable way.
+
+For instance, we may want to add pagination to our tables.
+
+Knoll exposes a few common extensions under the `knoll/extensions` namespace. You can use them like so:
+
+```jsx
+import { Table, Column } from 'knoll'
+import { compose, withFilter, withPagination } from 'knoll/extensions'
+
+const ExtendedTable = compose(
+  withFilter(['id', 'title', 'tags']),
+  withPagination(),
+)(Table)
+
+export default function MyComponent (props) {
+  return (
+    <ExtendedTable data={/* ... */}>
+      <Column header="ID" cellKey="id" />
+      <Column header="Title" cellKey="title" />
+    </ExtendedTable>
+  )
+}
+```
+
+*See the [advanced usage example](https://github.com/rosszurowski/knoll/tree/master/examples/advanced) for more details.*
+
+Using composition not only keeps code organized and local state out of components, but it also allows for a pluggable ecosystem, rather than monolithic solutions.
+
 ## Motivation
 
-Showing tabular data on the web has been a solved problem since 1997. But recent React components trying to make it easy all come off heavy-handed. Knoll tries to provide a simple and composable interface to building reactive tables.
+Showing tabular data on the web has been a solved problem since 1997. But recent React components for tables make it [quite heavy-handed](https://github.com/tannerlinsley/react-table#component-overrides). Knoll tries to provide a simple, composable, and elegant interface to building reactive tables.
 
 A few future plans:
 
-- [ ] Examples of using composition for searching, filtering, sorting
+- [x] Examples of using composition for searching, filtering, sorting
 - [ ] Examples of styling interior HTML components
 - [ ] Better documentation
 - [ ] Better test coverage

--- a/examples/advanced/package.json
+++ b/examples/advanced/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "knoll-advanced",
+  "version": "0.0.1",
+  "private": true,
+  "devDependencies": {
+    "react-scripts": "^0.9.3"
+  },
+  "dependencies": {
+    "react": "^15.3.0",
+    "react-dom": "^15.3.0",
+    "knoll": "^1.0.0"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "eject": "react-scripts eject",
+    "test": "react-scripts test"
+  }
+}

--- a/examples/advanced/public/index.html
+++ b/examples/advanced/public/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Redux Counter Example</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <!--
+      This HTML file is a template.
+      If you open it directly in the browser, you will see an empty page.
+      You can add webfonts, meta tags, or analytics to this file.
+      The build step will place the bundled scripts into the <body> tag.
+      To begin the development, run `npm start` in this folder.
+      To create a production bundle, use `npm run build`.
+    -->
+  </body>
+</html>

--- a/examples/advanced/src/advanced.js
+++ b/examples/advanced/src/advanced.js
@@ -1,0 +1,32 @@
+import React, { Component } from 'react'
+import ReactDOM from 'react-dom'
+
+import { Table, Column } from 'knoll'
+import { compose, withFilter, withPagination, withSorting } from 'knoll/extensions'
+
+const ExtendedTable = compose(
+  withFilter(['name', 'kind']),
+  withPagination(),
+  withSorting(),
+)(Table)
+
+const data = [
+  { id: 1, name: 'Birch', kind: 'coniferous', image: 'http...' },
+  { id: 2, name: 'Oak', kind: 'deciduous', image: 'http...' },
+  { id: 3, name: 'Maple', kind: 'deciduous', image: 'http...' },
+  { id: 4, name: 'Fir', kind: 'coniferous', image: 'http...' }
+]
+
+class App extends Component {
+  render () {
+    return (
+      <ExtendedTable data={data}>
+        <Column header="ID" cellKey="id" />
+        <Column header="Name" cellKey="name" />
+        <Column header="Kind" cellKey="kind" />
+      </ExtendedTable>
+    )
+  }
+}
+
+ReactDOM.render(<App />, document.getElementById('root'))

--- a/examples/basic-table/basic.js
+++ b/examples/basic-table/basic.js
@@ -1,4 +1,4 @@
-/* global React, ReactDOM */
+/* global React, ReactDOM, Knoll */
 
 const { Component } = React
 const { default: Table, Column } = Knoll

--- a/src/extensions/compose.js
+++ b/src/extensions/compose.js
@@ -1,0 +1,6 @@
+export default function compose (...funcs) {
+  return (...args) => {
+    const [fn, ...fns] = funcs.reverse()
+    return fns.reduce((acc, f) => f(acc), fn(...args))
+  }
+}

--- a/src/extensions/index.js
+++ b/src/extensions/index.js
@@ -1,0 +1,4 @@
+export compose from './compose'
+export withFilter from './with-filter'
+export withPagination from './with-pagination'
+export withSorting from './with-sorting'

--- a/src/extensions/with-filter.js
+++ b/src/extensions/with-filter.js
@@ -1,0 +1,43 @@
+import React, { Component, PropTypes } from 'react'
+
+const defaults = {
+  filter (data, predicate) {
+
+  }
+}
+
+const withFilter = opts => WrappedComponent => {
+  const { filter } = Object.assign({}, defaults, opts)
+
+  return class FilterableTable extends Component {
+    static propTypes = {
+      data: PropTypes.array.isRequired,
+    }
+
+    state = {
+      predicate: '',
+    }
+
+    handleSearchChange = (e) => {
+      this.setState({ filter: e.target.value })
+    }
+
+    render () {
+      const { data, ...props } = this.props
+      const { predicate } = this.state
+
+      const filteredData = filter(data, predicate)
+
+      return (
+        <div>
+          <div>
+            <input type="text" placeholder="Search..." onChange={this.handleSearchChange} />
+          </div>
+          <WrappedComponent data={filteredData} {...props} />
+        </div>
+      )
+    }
+  }
+}
+
+export default withFilter

--- a/src/extensions/with-pagination.js
+++ b/src/extensions/with-pagination.js
@@ -1,0 +1,63 @@
+/* global React */
+
+const { Component } = React
+
+const withPagination = () => WrappedComponent => (
+  class PaginatedTable extends Component {
+    state = {
+      currentPage: 0,
+      pageCount: 0,
+    }
+
+    componentWillMount () {
+      this.setState({
+        currentPage: this.props.defaultPage,
+      })
+    }
+
+    nextPage = () => {
+      const { currentPage, pageCount } = this.state
+
+      if (currentPage < pageCount - 1) {
+        this.setState({
+          currentPage: currentPage + 1,
+        })
+      }
+    }
+
+    previousPage = () => {
+      const { currentPage } = this.state
+
+      if (currentPage > 0) {
+        this.setState({
+          currentPage: currentPage - 1,
+        })
+      }
+    }
+
+    render () {
+      const { data, pageSize, ...props } = this.props
+      const { currentPage, pageCount } = this.state
+
+      const startIndex = pageSize * currentPage
+      const endIndex = pageSize * (currentPage + 1)
+
+      const pagedData = data.slice(startIndex, endIndex)
+
+      const canPagePrev = currentPage > 0
+      const canPageNext = currentPage < pageCount - 1
+
+      return (
+        <div>
+          <WrappedComponent data={pagedData} {...props} />
+          <div>
+            <a disabled={!canPagePrev} onClick={this.previousPage}>Prev</a>
+            <a disabled={!canPageNext} onClick={this.nextPage}>Next</a>
+          </div>
+        </div>
+      )
+    }
+  }
+)
+
+export default withPagination

--- a/src/extensions/with-sorting.js
+++ b/src/extensions/with-sorting.js
@@ -1,0 +1,15 @@
+import React, { Component } from 'react'
+
+const withSorting = opts => WrappedComponent => (
+  class SortableTable extends Component {
+    render () {
+      const { ...props } = this.props
+
+      return (
+        <WrappedComponent {...props} />
+      )
+    }
+  }
+)
+
+export default withSorting


### PR DESCRIPTION
This PR adds a few higher-order components with knoll to provide common table functionality like sorting, filtering, and pagination.

Still lots of work to be done. Need to figure out the best way to make the interface extendable to work for most use-cases. Will probably punt on more complex pieces (eg. async filtering / fetching) for now.

- [ ] Add pagination (with options)
- [ ] Add filtering (with options)
- [ ] Add sorting (with options)
- [ ] Documentation
- [ ] Tests